### PR TITLE
Fix so adding vertex if vertex didn't exist

### DIFF
--- a/src/uk/ac/lancaster/scc/data/lab3/GraphAnalyser.java
+++ b/src/uk/ac/lancaster/scc/data/lab3/GraphAnalyser.java
@@ -44,10 +44,10 @@ public class GraphAnalyser {
                 String targetNode = tokens[1];  // to
 
                 // add the nodes to the graph object
-                if(graph.containsVertex(sourceNode))
+                if(!graph.containsVertex(sourceNode))
                     graph.addVertex(sourceNode);
 
-                if(graph.containsVertex(targetNode))
+                if(!graph.containsVertex(targetNode))
                     graph.addVertex(targetNode);
 
                 // add the edge to the graph


### PR DESCRIPTION
Think it worked before because the library might have been doing it automatically when `addEdge()` was called.